### PR TITLE
ft: patch http parser to allow slash(/) for headers

### DIFF
--- a/deps/http_parser/http_parser.h
+++ b/deps/http_parser/http_parser.h
@@ -227,6 +227,7 @@ struct http_parser {
   unsigned int header_state : 7; /* enum header_state from http_parser.c */
   unsigned int index : 7;        /* index into current matcher */
   unsigned int lenient_http_headers : 1;
+  unsigned int lenient_http_header_names : 1;
 
   uint32_t nread;          /* # bytes read in various scenarios */
   uint64_t content_length; /* # bytes in body (0 if no Content-Length header) */

--- a/lib/_http_common.js
+++ b/lib/_http_common.js
@@ -256,6 +256,9 @@ function checkIsHttpToken(val) {
     if (ch === 94 || ch === 95 || ch === 96 || ch === 124 || ch === 126)
       continue;
 
+    if (ch === 47) // slash character (/)
+      continue;
+
     if (ch >= 48 && ch <= 57) // 0-9
       continue;
 

--- a/src/node_version.h
+++ b/src/node_version.h
@@ -17,7 +17,7 @@
 
 #ifndef NODE_TAG
 # if NODE_VERSION_IS_RELEASE
-#  define NODE_TAG ""
+#  define NODE_TAG "-scality.1"
 # else
 #  define NODE_TAG "-pre"
 # endif


### PR DESCRIPTION

This patch whitelists slash(/) as an acceptable character for header tokens.